### PR TITLE
Fixed transition patch triangulation of adaptive tessellation

### DIFF
--- a/src/eval/tessellate.js
+++ b/src/eval/tessellate.js
@@ -735,7 +735,7 @@ verb.eval.nurbs.AdaptiveRefinementNode.prototype.getAllEdgeUvs = function( edgeI
 
 verb.eval.nurbs.AdaptiveRefinementNode.prototype.triangulateLeaf = function( mesh ){
 
-	var baseIndex = mesh.points.length - 1;
+	var baseIndex = mesh.points.length;
 	var uvs = [];
 
 	// enumerate all uvs in counter clockwise direction
@@ -756,8 +756,8 @@ verb.eval.nurbs.AdaptiveRefinementNode.prototype.triangulateLeaf = function( mes
 
 		// if the number of points is 4, we're just doing a
 		// rectangle - just build the basic triangulated square
-		mesh.faces.push( [ baseIndex + 1, baseIndex + 4, baseIndex + 2 ] );
-		mesh.faces.push( [ baseIndex + 4, baseIndex + 3, baseIndex + 2 ] );
+		mesh.faces.push( [ baseIndex + 0, baseIndex + 3, baseIndex + 1 ] );
+		mesh.faces.push( [ baseIndex + 3, baseIndex + 2, baseIndex + 1 ] );
 
 		// all done ;)
 		return mesh;
@@ -777,15 +777,14 @@ verb.eval.nurbs.AdaptiveRefinementNode.prototype.triangulateLeaf = function( mes
 	var centerIndex = mesh.points.length - 1;
 
 	// build triangle fan from center
-	for (var i = 0; i < uvs.length; i++){
-
+	for (var i = 0, j = uvs.length-1; i < uvs.length; j = i++){
 		console.log( [centerIndex, 
-												(baseIndex + i + 2) % uvs.length, 
-												(baseIndex + i + 1) % uvs.length   ] );
+												baseIndex + j, 
+												baseIndex + i   ] );
 
 		mesh.faces.push( [	centerIndex, 
-												(baseIndex + i + 2) % uvs.length, 
-												(baseIndex + i + 1) % uvs.length   ]);
+												baseIndex + j, 
+												baseIndex + i   ]);
 
 	}
 


### PR DESCRIPTION
AdaptiveRefinementNode.triangulateLeaf() had modulo mixed up, which caused the triangles to use indices in 0...n range (i.e. one corner of the surface). This change fixes the triangulation of the transition patches.
