### PR TITLE
Make verb-nurbs work as a node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "geometry",
     "cad"
   ],
+  "dependencies": {
+      "webworker-threads": "0.6.2",
+  },
   "devDependencies": {
     "benchmark": "^1.0.0",
     "grunt": "0.4.5",
@@ -29,7 +32,6 @@
     "grunt-text-replace": "^0.4.0",
     "mocha": "^2.2.4",
     "should": "6.0.1",
-    "webworker-threads": "0.6.2",
     "tess2": "^1.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cad"
   ],
   "dependencies": {
-      "webworker-threads": "0.6.2",
+      "webworker-threads": "0.6.2"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "grunt -v test"
   },
   "engine": "node 4.2.1",
+  "main": "build/js/verb.js",
   "keywords": [
     "NURBS",
     "geometry",


### PR DESCRIPTION
Hello!

Great library you have here. I'm using it in a project as a node module and it works great.

The only two minor things I found that was off was that webworker-threads didn't get installed and that the main property is missing from package.json.

My suggestions are in this pull request. If you don't think that's the way to go then adding documentation that using it as a node module is possible by using 
```javascript
var verb = require( './node_modules/verb-nurbs/build/js/verb.js' );
``` 
would be the second best thing.

Thanks!