### PR TITLE
to three conversion: avoid RangeErrors when dealing with large arrays

### DIFF
--- a/examples/js/verbToThreeConversion.js
+++ b/examples/js/verbToThreeConversion.js
@@ -16,14 +16,10 @@
         });
     }
 
-    function asGeometry(threePts){
-        var geometry = new THREE.Geometry();
-        geometry.vertices.push.apply( geometry.vertices, threePts );
-        return geometry;
-    }
-
     function tessellateCurve( curve ){
-        return asGeometry( asVector3(  curve.tessellate() ) );
+        var geometry = new THREE.Geometry();
+        geometry.vertices = asVector3( curve.tessellate() );
+        return geometry;
     }
 
     function tessellateSurface(srf) {
@@ -31,11 +27,10 @@
         var tess = srf.tessellate();
 
         var geometry = new THREE.Geometry();
-        var threePts = asVector3( tess.points );
 
-        geometry.vertices.push.apply( geometry.vertices, threePts );
+        geometry.vertices = asVector3( tess.points );
 
-        var threeFaces = tess.faces.map(function(faceIndices){
+        geometry.faces = tess.faces.map(function(faceIndices){
             var normals = faceIndices.map(function(x){
                 var vn = tess.normals[x];
                 return new THREE.Vector3( vn[0], vn[1], vn[2] );
@@ -44,7 +39,6 @@
             return new THREE.Face3(faceIndices[0],faceIndices[1],faceIndices[2], normals);
         });
 
-        geometry.faces.push.apply(geometry.faces, threeFaces);
         return geometry;
     }
 


### PR DESCRIPTION
Current implementation: `destinationArray.push.apply(destinationArray, sourceArray);` fails to process large arrays (at least it fails at ~130k elements for me) with the `RangeError: Maximum call stack size exceeded`. Since neither `threePts` nor `threeFaces` is actually used later, they just duplicate memory consumption and can be removed in favor of direct `geometry.vertices` and `geometry.faces` manipulation.