### PR TITLE
fix(verb): corrected exposure for AdaptiveRefinementNode and AdaptiveRefinementOptions

### DIFF
--- a/build/js/verb.es.js
+++ b/build/js/verb.es.js
@@ -185,8 +185,8 @@ var verbHaxe = {};
 	    attachTo.clearImmediate = clearImmediate;
 	}(new Function("return this")()));
 (function ($hx_exports, $global) {	$hx_exports["promhx"] = $hx_exports["promhx"] || {};
-	$hx_exports["eval"] = $hx_exports["eval"] || {};
 	$hx_exports["core"] = $hx_exports["core"] || {};
+	$hx_exports["eval"] = $hx_exports["eval"] || {};
 	$hx_exports["exe"] = $hx_exports["exe"] || {};
 	$hx_exports["geom"] = $hx_exports["geom"] || {};
 	var $hxClasses = {},$estr = function() { return js_Boot.__string_rec(this,''); },$hxEnums = $hxEnums || {},$_;
@@ -7544,7 +7544,7 @@ var verbHaxe = {};
 		var arrTrees = verb_eval_Tess.divideRationalSurfaceAdaptive(surface,options);
 		return verb_eval_Tess.triangulateAdaptiveRefinementNodeTree(arrTrees);
 	};
-	var verb_eval_AdaptiveRefinementOptions = $hx_exports["core"]["AdaptiveRefinementOptions"] = function() {
+	var verb_eval_AdaptiveRefinementOptions = $hx_exports["eval"]["AdaptiveRefinementOptions"] = function() {
 		this.minDivsV = 1;
 		this.minDivsU = 1;
 		this.refine = true;
@@ -7557,7 +7557,7 @@ var verbHaxe = {};
 	verb_eval_AdaptiveRefinementOptions.prototype = {
 		__class__: verb_eval_AdaptiveRefinementOptions
 	};
-	var verb_eval_AdaptiveRefinementNode = $hx_exports["core"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
+	var verb_eval_AdaptiveRefinementNode = $hx_exports["eval"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
 		this.srf = srf;
 		this.neighbors = neighbors == null ? [null,null,null,null] : neighbors;
 		this.corners = corners;

--- a/build/js/verb.min.js
+++ b/build/js/verb.min.js
@@ -189,8 +189,8 @@
 		    attachTo.clearImmediate = clearImmediate;
 		}(new Function("return this")()));
 	(function ($hx_exports, $global) {	$hx_exports["promhx"] = $hx_exports["promhx"] || {};
-		$hx_exports["eval"] = $hx_exports["eval"] || {};
 		$hx_exports["core"] = $hx_exports["core"] || {};
+		$hx_exports["eval"] = $hx_exports["eval"] || {};
 		$hx_exports["exe"] = $hx_exports["exe"] || {};
 		$hx_exports["geom"] = $hx_exports["geom"] || {};
 		var $hxClasses = {},$estr = function() { return js_Boot.__string_rec(this,''); },$hxEnums = $hxEnums || {},$_;
@@ -7548,7 +7548,7 @@
 			var arrTrees = verb_eval_Tess.divideRationalSurfaceAdaptive(surface,options);
 			return verb_eval_Tess.triangulateAdaptiveRefinementNodeTree(arrTrees);
 		};
-		var verb_eval_AdaptiveRefinementOptions = $hx_exports["core"]["AdaptiveRefinementOptions"] = function() {
+		var verb_eval_AdaptiveRefinementOptions = $hx_exports["eval"]["AdaptiveRefinementOptions"] = function() {
 			this.minDivsV = 1;
 			this.minDivsU = 1;
 			this.refine = true;
@@ -7561,7 +7561,7 @@
 		verb_eval_AdaptiveRefinementOptions.prototype = {
 			__class__: verb_eval_AdaptiveRefinementOptions
 		};
-		var verb_eval_AdaptiveRefinementNode = $hx_exports["core"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
+		var verb_eval_AdaptiveRefinementNode = $hx_exports["eval"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
 			this.srf = srf;
 			this.neighbors = neighbors == null ? [null,null,null,null] : neighbors;
 			this.corners = corners;

--- a/build/js/verbHaxe.js
+++ b/build/js/verbHaxe.js
@@ -177,8 +177,8 @@
 
 ;(function ($hx_exports, $global) { "use strict";
 $hx_exports["promhx"] = $hx_exports["promhx"] || {};
-$hx_exports["eval"] = $hx_exports["eval"] || {};
 $hx_exports["core"] = $hx_exports["core"] || {};
+$hx_exports["eval"] = $hx_exports["eval"] || {};
 $hx_exports["exe"] = $hx_exports["exe"] || {};
 $hx_exports["geom"] = $hx_exports["geom"] || {};
 var $hxClasses = {},$estr = function() { return js_Boot.__string_rec(this,''); },$hxEnums = $hxEnums || {},$_;
@@ -7560,7 +7560,7 @@ verb_eval_Tess.rationalSurfaceAdaptive = function(surface,options) {
 	var arrTrees = verb_eval_Tess.divideRationalSurfaceAdaptive(surface,options);
 	return verb_eval_Tess.triangulateAdaptiveRefinementNodeTree(arrTrees);
 };
-var verb_eval_AdaptiveRefinementOptions = $hx_exports["core"]["AdaptiveRefinementOptions"] = function() {
+var verb_eval_AdaptiveRefinementOptions = $hx_exports["eval"]["AdaptiveRefinementOptions"] = function() {
 	this.minDivsV = 1;
 	this.minDivsU = 1;
 	this.refine = true;
@@ -7573,7 +7573,7 @@ verb_eval_AdaptiveRefinementOptions.__name__ = "verb.eval.AdaptiveRefinementOpti
 verb_eval_AdaptiveRefinementOptions.prototype = {
 	__class__: verb_eval_AdaptiveRefinementOptions
 };
-var verb_eval_AdaptiveRefinementNode = $hx_exports["core"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
+var verb_eval_AdaptiveRefinementNode = $hx_exports["eval"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
 	this.srf = srf;
 	this.neighbors = neighbors == null ? [null,null,null,null] : neighbors;
 	this.corners = corners;

--- a/examples/js/verb.min.js
+++ b/examples/js/verb.min.js
@@ -189,8 +189,8 @@
 		    attachTo.clearImmediate = clearImmediate;
 		}(new Function("return this")()));
 	(function ($hx_exports, $global) {	$hx_exports["promhx"] = $hx_exports["promhx"] || {};
-		$hx_exports["eval"] = $hx_exports["eval"] || {};
 		$hx_exports["core"] = $hx_exports["core"] || {};
+		$hx_exports["eval"] = $hx_exports["eval"] || {};
 		$hx_exports["exe"] = $hx_exports["exe"] || {};
 		$hx_exports["geom"] = $hx_exports["geom"] || {};
 		var $hxClasses = {},$estr = function() { return js_Boot.__string_rec(this,''); },$hxEnums = $hxEnums || {},$_;
@@ -7548,7 +7548,7 @@
 			var arrTrees = verb_eval_Tess.divideRationalSurfaceAdaptive(surface,options);
 			return verb_eval_Tess.triangulateAdaptiveRefinementNodeTree(arrTrees);
 		};
-		var verb_eval_AdaptiveRefinementOptions = $hx_exports["core"]["AdaptiveRefinementOptions"] = function() {
+		var verb_eval_AdaptiveRefinementOptions = $hx_exports["eval"]["AdaptiveRefinementOptions"] = function() {
 			this.minDivsV = 1;
 			this.minDivsU = 1;
 			this.refine = true;
@@ -7561,7 +7561,7 @@
 		verb_eval_AdaptiveRefinementOptions.prototype = {
 			__class__: verb_eval_AdaptiveRefinementOptions
 		};
-		var verb_eval_AdaptiveRefinementNode = $hx_exports["core"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
+		var verb_eval_AdaptiveRefinementNode = $hx_exports["eval"]["AdaptiveRefinementNode"] = function(srf,corners,neighbors) {
 			this.srf = srf;
 			this.neighbors = neighbors == null ? [null,null,null,null] : neighbors;
 			this.corners = corners;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verb-nurbs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "pboyer <peter.b.boyer@gmail.com>",
   "description": "A CAD library for the web",
   "repository": {
@@ -31,7 +31,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
-    "mocha": "10.6.0",
+    "mocha": "^10.6.0",
     "rollup": "^4.18.0",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "should": "^13.2.3"

--- a/src/verb/eval/Tess.hx
+++ b/src/verb/eval/Tess.hx
@@ -354,7 +354,7 @@ class Tess {
 
 }
 
-@:expose("core.AdaptiveRefinementOptions")
+@:expose("eval.AdaptiveRefinementOptions")
 class AdaptiveRefinementOptions {
     public var normTol : Float = 2.5e-2;
     public var minDepth : Int = 0;
@@ -391,7 +391,7 @@ class AdaptiveRefinementOptions {
 //                        neighbors[0]
 //```
 
-@:expose("core.AdaptiveRefinementNode")
+@:expose("eval.AdaptiveRefinementNode")
 class AdaptiveRefinementNode {
 
     var srf : NurbsSurfaceData;


### PR DESCRIPTION
These are small changes to the exposures. It was kind of frustrating to not find the documented classes.

New build as well for version 3.0.1

fixes #61 